### PR TITLE
Once the device is connect and the user start paginating the address …

### DIFF
--- a/src/components/HardWallet.jsx
+++ b/src/components/HardWallet.jsx
@@ -155,7 +155,10 @@ class HardWallet extends React.Component {
 
     if (this.page.end === addresses.length) {
       const {error} = await this.props.loadHWAddresses("kovan", this.page.end + 5, this.derivationPath);
-      if (error) console.log("Error connecting with the device"); //TODO: handle it somehow - probably some notification box? This happen with TREZOR.
+      if (error) {
+        console.log("Error connecting with the device");
+        return;
+      } //TODO: handle it somehow - probably some notification box? This happen with TREZOR.
 
       page.end = this.props.hw.addresses.length;
     }


### PR DESCRIPTION
…if the device get's disconnect  then on error ( timeout or window being closed ) an empty page of addresses is loaded. The fix includes a logic that will return and the last page will be left on the display.